### PR TITLE
Add .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Bearer Token from Twitter (see readme for instructions on where to get one)
+BEARER="<YOUR_TWITTER_BEARER_TOKEN>"

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 # Project files
-# Output generated after scraping
+## Output generated after scraping
 index.html
 tweets.txt
+
+## Secrets
+.env
 
 # OS Files
 .DS_Store

--- a/README.MD
+++ b/README.MD
@@ -97,7 +97,7 @@ To get a local copy up and running follow these simple example steps.
 
 ### Installation
 
-1. Get a free twitter API Key from [developer.twitter.com](https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api). Remember to create a new app and get the bearer key.
+1. Get a free twitter Bearer Token from [developer.twitter.com](https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api). Remember to create a new app and get the bearer token.
 2. Clone the repo
    ```sh
    git clone https://github.com/kinshukdua/LiveActionMap.git
@@ -106,10 +106,11 @@ To get a local copy up and running follow these simple example steps.
    ```sh
    pip install -r requirements.txt
    ```
-4. Open scrape.py and change the bearer key to your own.
-   ```python
-   bearer_token = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+4. Create a `.env` file based on the `.env.example`
+   ```sh
+   cp .env.example .env
    ```
+5. Set the Twitter bearer token to your own in the `.env` file created in the previous step.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ folium
 geopy
 tqdm
 geograpy3
+python-dotenv>=0.19.2

--- a/scrape.py
+++ b/scrape.py
@@ -2,6 +2,10 @@ import tweepy
 import datetime
 from plot import Map
 import os
+from dotenv import load_dotenv
+
+# Load envs from the .env
+load_dotenv()
 
 class Scraper:
     def __init__(self, bearer_token, filename="tweets.txt"):
@@ -64,7 +68,6 @@ class Scraper:
 
 # EXAMPLE
 if __name__ == "__main__":
-    # Add your twitter token here
     bearer_token = os.environ["BEARER"]
     s = Scraper(bearer_token)
     hashtags = ["#ukraine","#russianarmy"]


### PR DESCRIPTION
Add support for .env so that it's easier to set the Twitter Bearer Token. It eliminates the need to set an environment variable on the shell or hardcoding the token to the `scrape.py`.

Blocked by PR #8 