### PR TITLE
fix ci, use curl to trigger gitlab deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,8 +43,5 @@ jobs:
       - name: Deploy job
         # trigger job only on push on main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/gitlab-ci-action@master
-        with:
-          token: ${{ secrets.GITLAB_TOKEN }}
-          project_id: "34155787"
-          ref: ${{ secrets.GITLAB_REF_NAME }}
+        run: curl --request POST "https://gitlab.com/api/v4/projects/34155787/trigger/pipeline?token=${{ secrets.GITLAB_TOKEN }}&ref=main"
+        shell: bash


### PR DESCRIPTION
instead of using a third-party GitHub action.

#52 
I've used just the token secret, the gitlab ref name is hardcoded to master.

I haven't tested it, as I'd need the secret value and gitlab access.